### PR TITLE
Improve synthetic time step realism

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -6,9 +6,9 @@ import matplotlib.pyplot as plt
 from scipy.stats import gaussian_kde
 
 # --- 1. تنظیمات اولیه: مسیر کامل پوشه‌ها ---
-# لطفاً مطمئن شوید این مسیرها دقیقاً با ساختار پوشه شما مطابقت دارند
-GENERATED_DATA_DIR = r'D:\work_station\radar\final\data_generated_final_fixed'
-REAL_DATA_DIR = r'D:\work_station\radar_co\radar\final\data2\project_files\lstm_out\real' # مسیر اصلاح شده
+# مسیرها به‌صورت نسبی تنظیم شده‌اند تا در هر محیطی قابل اجرا باشند
+GENERATED_DATA_DIR = os.path.join(os.getcwd(), 'generated_data')
+REAL_DATA_DIR = os.path.join(os.getcwd(), 'data real')
 
 # نتایج در پوشه‌ای به این نام در کنار اسکریپت ذخیره می‌شوند
 OUTPUT_DIR = 'analysis_results_final_v2'


### PR DESCRIPTION
## Summary
- add balance_time_step_distribution to nudge generated time gaps toward real-world proportions
- apply time-step balancing after clamping and synchronized-time injection

## Testing
- `pip install pandas numpy matplotlib scipy`
- `python -m py_compile generate_data_patched.py analyze.py`
- `python generate_data_patched.py <<'EOF'
1
5000
link
EOF`
- `python generate_data_patched.py <<'EOF'
1
5000
mode
EOF`
- `python analyze.py >/tmp/analysis.log && tail -n 20 /tmp/analysis.log`


------
https://chatgpt.com/codex/tasks/task_e_68aeba95be9483249c7714b179bfb90e